### PR TITLE
Redirect to first show

### DIFF
--- a/app/routes/index.ts
+++ b/app/routes/index.ts
@@ -1,6 +1,15 @@
 import type { LoaderFunction } from '@remix-run/node';
 import { redirect } from '@remix-run/node';
 
-export const loader = (() => {
-  return redirect('/my-show');
+import { db } from '~/db/db.server';
+
+const notFound = () => new Response('Not Found', { status: 404 });
+
+export const loader = (async () => {
+  const show = await db.show.findFirst({
+    orderBy: { startDate: 'asc' },
+  });
+  if (!show) throw notFound();
+
+  return redirect(`/${show.id}`);
 }) satisfies LoaderFunction;


### PR DESCRIPTION
This needs to be improved later to add show validation and caching - for now, this allows us to run a show from the homepage without hard-coding any show ID.