### PR TITLE
Fix Vite alias config in Playwright component test

### DIFF
--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { defineConfig, devices } from '@playwright/experimental-ct-react';
 
 /**
@@ -19,7 +21,7 @@ export default defineConfig({
       resolve: {
         // Match "paths" in tsconfig.json
         alias: {
-          '~': '/app',
+          '~': resolve(__dirname, 'app'),
         },
       },
     },


### PR DESCRIPTION
This will make the config compatible with Playwright v1.42. See microsoft/playwright#29916.