### PR TITLE
Explicitly use macos-12 for CI

### DIFF
--- a/.github/workflows/test-ct.yml
+++ b/.github/workflows/test-ct.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         shardIndex: [1, 2, 3]
         shardTotal: [3]
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Check out repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
macos-14, which will soon become macos-latest, doesn't work with CI in this repo.