### PR TITLE
Revert "Disable Renovate automerge ahead of the next show (#1548)"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,12 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "digest"],
-      "automerge": false
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "!/^[~^]?0/",
-      "automerge": false
+      "automerge": true
     },
     {
       "matchUpdateTypes": ["minor"],
@@ -21,6 +21,6 @@
   "lockFileMaintenance": {
     "enabled": true,
     "extends": ["schedule:weekly"],
-    "automerge": false
+    "automerge": true
   }
 }


### PR DESCRIPTION
This reverts commit 4704407f821f5c66de03171673f443eb1804cb0f.