### PR TITLE
Fix date bugs; replace Date with Temporal

### DIFF
--- a/app/components/AudioController/AudioController.tsx
+++ b/app/components/AudioController/AudioController.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/media-has-caption */
 
-import { differenceInSeconds } from 'date-fns';
 import type { AudioHTMLAttributes, FC, ReactNode, SyntheticEvent } from 'react';
 import {
   useCallback,
@@ -248,10 +247,9 @@ export const AudioController: FC<AudioControllerProps> = ({
           showInfo.currentSet &&
           change.currentSet.id !== showInfo.currentSet.id
         ) {
-          const setDifference = differenceInSeconds(
-            change.currentSet.start,
-            showInfo.currentSet.start,
-          );
+          const setDifference = showInfo.currentSet.start
+            .until(change.currentSet.start)
+            .total({ unit: 'seconds' });
           delay += setDifference;
         }
 

--- a/app/forms/show/schema.ts
+++ b/app/forms/show/schema.ts
@@ -28,7 +28,18 @@ export const schema = zfd.formData({
       message: 'Invalid show URL',
     }),
   ),
-  startDate: zfd.text(z.string().datetime({ local: true }).optional()),
+  startDate: zfd.text(
+    z
+      .string()
+      .refine(
+        (val) =>
+          // The value of a `datetime-local` input doesn't include seconds if they are 0,
+          // so we can't use `.datetime()` here.
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?/.test(val),
+        { message: 'Invalid date/time' },
+      )
+      .optional(),
+  ),
   timeZone: zfd.text(
     z.string().refine(isValidTimeZone, { message: 'Invalid time zone' }),
   ),

--- a/app/hooks/useClock.ts
+++ b/app/hooks/useClock.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Temporal } from 'temporal-polyfill';
 
 function getCurrentSecond() {
-  return Math.floor(Date.now() / 1000);
+  return Math.floor(Temporal.Now.instant().epochMilliseconds / 1000);
 }
 
 export function useClock(enabled = true): void {

--- a/app/hooks/useShowInfo.ts
+++ b/app/hooks/useShowInfo.ts
@@ -1,5 +1,5 @@
-import { addMilliseconds, addSeconds, isBefore, parseISO } from 'date-fns';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Temporal } from 'temporal-polyfill';
 
 import type { loader as showDataLoader } from '~/routes/$show.[data.json]';
 import type { ShowData } from '~/types/ShowData';
@@ -9,6 +9,10 @@ import { useClock } from './useClock';
 import { useFetcherIgnoreErrors } from './useFetcherIgnoreErrors';
 
 type LoadedMetadataHandler = (args: { id: string; duration: number }) => void;
+
+function isBefore(a: Temporal.Instant, b: Temporal.Instant): boolean {
+  return Temporal.Instant.compare(a, b) === -1;
+}
 
 export function useShowInfo(
   loaderData: Pick<ShowData, 'slug' | 'serverDate' | 'sets'>,
@@ -46,48 +50,54 @@ export function useShowInfo(
   const data = fetcher.data ?? loaderData;
 
   const clientTimeSkewMs = useMemo(() => {
-    const serverDate = parseISO(data.serverDate);
+    const serverDate = Temporal.Instant.from(data.serverDate);
 
-    return Date.now() - serverDate.valueOf();
+    return (
+      Temporal.Now.instant().epochMilliseconds - serverDate.epochMilliseconds
+    );
   }, [data.serverDate]);
 
   const sets = useMemo(() => {
     return data.sets
       .map(function parseDates(set) {
-        const start = parseISO(set.start);
+        const start = Temporal.Instant.from(set.start);
 
         const length = audioDurations[set.id] ?? set.duration;
-        const end = addSeconds(start, length);
+        const end = start.add({ seconds: length });
 
         return { ...set, start, end };
       })
       .map(function adjustForClientTimeSkew(set) {
-        const start = addMilliseconds(set.start, clientTimeSkewMs);
-        const end = addMilliseconds(set.end, clientTimeSkewMs);
+        const start = set.start.add({ milliseconds: clientTimeSkewMs });
+        const end = set.end.add({ milliseconds: clientTimeSkewMs });
 
         return { ...set, start, end };
       });
   }, [audioDurations, clientTimeSkewMs, data.sets]);
 
   const currentSetIndex = sets.findIndex((set) =>
-    isBefore(Date.now(), set.end),
+    isBefore(Temporal.Now.instant(), set.end),
   );
   const currentSet = currentSetIndex === -1 ? undefined : sets[currentSetIndex];
   const nextSet =
     currentSetIndex === -1 ? undefined : sets[currentSetIndex + 1];
 
   const timeInfo: TargetTimeInfo = currentSet
-    ? isBefore(Date.now(), currentSet.start)
+    ? isBefore(Temporal.Now.instant(), currentSet.start)
       ? {
           status: 'WAITING_UNTIL_START',
           secondsUntilSet: Math.ceil(
-            (currentSet.start.valueOf() - Date.now()) / 1000,
+            Temporal.Now.instant()
+              .until(currentSet.start)
+              .total({ unit: 'seconds' }),
           ),
         }
       : {
           status: 'PLAYING',
           currentTime: Math.floor(
-            (Date.now() - currentSet.start.valueOf()) / 1000,
+            currentSet.start
+              .until(Temporal.Now.instant())
+              .total({ unit: 'seconds' }),
           ),
         }
     : { status: 'ENDED' };

--- a/app/routes/$show.[data.json].ts
+++ b/app/routes/$show.[data.json].ts
@@ -1,5 +1,5 @@
 import { json, type LoaderFunction } from '@remix-run/node';
-import { addSeconds, formatISO } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import { db } from '~/db.server/db';
 import type { ShowData } from '~/types/ShowData';
@@ -28,10 +28,12 @@ export const loader = (async ({ params }) => {
       id: set.id,
       audioUrl: set.audioFile.url,
       artist: set.artist,
-      start: addSeconds(show.startDate, set.offset).toISOString(),
+      start: Temporal.Instant.from(show.startDate)
+        .add({ seconds: set.offset })
+        .toString(),
       duration: set.audioFile.duration,
     })),
-    serverDate: formatISO(new Date()),
+    serverDate: Temporal.Now.instant().toString(),
   };
 
   // Single Fetch doesn't work with Clerk

--- a/app/routes/admin.shows.$show_.edit.tsx
+++ b/app/routes/admin.shows.$show_.edit.tsx
@@ -7,7 +7,7 @@ import { json, redirect } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import type { FC } from 'react';
 import { validationError } from 'remix-validated-form';
-import { Temporal, toTemporalInstant } from 'temporal-polyfill';
+import { Temporal } from 'temporal-polyfill';
 
 import { redirectToLogin } from '~/auth/redirect-to-login.server';
 import { cache, INDEX_SHOW_SLUG_KEY } from '~/cache.server/cache';
@@ -41,8 +41,7 @@ export const loader = (async (args) => {
   if (!show) throw notFound();
 
   const startDate = show.startDate
-    ? toTemporalInstant
-        .call(show.startDate)
+    ? Temporal.Instant.from(show.startDate)
         .toZonedDateTimeISO(show.timeZone)
         .toPlainDateTime()
         .toString({ smallestUnit: 'second' })
@@ -74,21 +73,19 @@ export const action = (async (args) => {
   const { data, error } = await validator.validate(form);
   if (error) return validationError(error);
 
-  const { sets, ...rest } = replaceUndefinedsWithNull(data);
+  const { startDate, sets, ...rest } = replaceUndefinedsWithNull(data);
 
-  const startDate = rest.startDate
-    ? new Date(
-        Temporal.PlainDateTime.from(rest.startDate).toZonedDateTime(
-          rest.timeZone,
-        ).epochMilliseconds,
-      )
-    : null;
+  const startInstant = startDate
+    ? Temporal.PlainDateTime.from(startDate)
+        .toZonedDateTime(rest.timeZone)
+        .toInstant()
+    : undefined;
 
   await db.show.update({
     where: { id },
     data: {
       ...rest,
-      startDate,
+      startDate: startInstant?.toString(),
       sets: {
         deleteMany: {
           id: { notIn: sets.map((set) => set.id).filter(isDefined) },

--- a/app/types/ShowInfo.ts
+++ b/app/types/ShowInfo.ts
@@ -1,8 +1,10 @@
+import type { Temporal } from 'temporal-polyfill';
+
 import type { SetData } from './ShowData';
 
 type SetInfo = Omit<SetData, 'start'> & {
-  start: Date;
-  end: Date;
+  start: Temporal.Instant;
+  end: Temporal.Instant;
 };
 
 interface SetsInfo {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,19 @@ export default tseslint.config(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       ...reactHooks.configs.recommended.rules,
 
+      'no-restricted-globals': [
+        'error',
+        { name: 'Date', message: 'Use `Temporal` instead.' },
+      ],
+      '@typescript-eslint/no-restricted-types': [
+        'error',
+        {
+          types: {
+            Date: 'Use `Temporal` instead.',
+          },
+        },
+      ],
+
       'no-plusplus': 'error',
       'object-shorthand': 'warn',
       quotes: ['warn', 'single', { avoidEscape: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@remix-run/react": "2.15.3",
         "@remix-run/serve": "2.15.3",
         "@remix-validated-form/with-zod": "2.0.7",
-        "date-fns": "3.6.0",
         "nanoid": "5.0.9",
         "node-cache": "5.1.2",
         "react": "18.3.1",
@@ -5016,16 +5015,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@remix-run/react": "2.15.3",
     "@remix-run/serve": "2.15.3",
     "@remix-validated-form/with-zod": "2.0.7",
-    "date-fns": "3.6.0",
     "nanoid": "5.0.9",
     "node-cache": "5.1.2",
     "react": "18.3.1",

--- a/playwright/ct-tests/AudioController/AudioControllerTest.tsx
+++ b/playwright/ct-tests/AudioController/AudioControllerTest.tsx
@@ -1,9 +1,9 @@
 import { json } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { createRemixStub } from '@remix-run/testing';
-import { addSeconds } from 'date-fns';
 import type { FC } from 'react';
 import { useState } from 'react';
+import { Temporal } from 'temporal-polyfill';
 import { useDeepCompareMemo } from 'use-deep-compare';
 
 import type { AudioMetadata } from '~/components/AudioController';
@@ -31,7 +31,7 @@ function getMockData({
   alternate = false,
   empty = false,
 }: GetMockDataProps): Pick<ShowData, 'slug' | 'serverDate' | 'sets'> {
-  const now = new Date();
+  const now = Temporal.Now.instant();
 
   const sets: ShowData['sets'] = empty
     ? []
@@ -40,21 +40,21 @@ function getMockData({
           id: alternate ? ID_3 : ID_1,
           audioUrl: `${AUDIO_FILE_URL}?${alternate ? 3 : 1}`,
           artist: `Artist ${alternate ? 3 : 1}`,
-          start: addSeconds(now, 0 - offsetSec).toISOString(),
+          start: now.add({ seconds: 0 - offsetSec }).toString(),
           duration: AUDIO_FILE_LENGTH,
         },
         {
           id: alternate ? ID_4 : ID_2,
           audioUrl: `${AUDIO_FILE_URL}?${alternate ? 4 : 2}`,
           artist: `Artist ${alternate ? 4 : 2}`,
-          start: addSeconds(now, 100 - offsetSec).toISOString(),
+          start: now.add({ seconds: 100 - offsetSec }).toString(),
           duration: AUDIO_FILE_LENGTH,
         },
       ];
 
   return {
     slug: 'test',
-    serverDate: now.toISOString(),
+    serverDate: now.toString(),
     sets,
   };
 }

--- a/playwright/ct-tests/ShowPlaying/ShowPlaying.spec.tsx
+++ b/playwright/ct-tests/ShowPlaying/ShowPlaying.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { addSeconds } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import type { ShowPlayingProps } from '~/components/ShowPlaying';
 import { ShowPlaying } from '~/components/ShowPlaying';
@@ -14,8 +14,8 @@ function makeShowInfoWaitingUntilStart(secondsUntilSet: number) {
       id: 'e465d3cf-7875-3fd9-915c-91a915bb8187',
       audioUrl: 'sample/fulton.mp3',
       artist: 'Fulton',
-      start: addSeconds(Date.now(), secondsUntilSet),
-      end: addSeconds(Date.now(), secondsUntilSet + 30),
+      start: Temporal.Now.instant().add({ seconds: secondsUntilSet }),
+      end: Temporal.Now.instant().add({ seconds: secondsUntilSet + 30 }),
       duration: 30,
     },
   } satisfies ShowInfo;
@@ -29,8 +29,8 @@ function makeShowInfoPlaying(currentTime: number) {
       id: '69859842-c6ac-3aa4-8f0d-358ff7758b9e',
       audioUrl: 'sample/dana.mp3',
       artist: 'Dana',
-      start: addSeconds(Date.now(), -currentTime),
-      end: addSeconds(Date.now(), 30 - currentTime),
+      start: Temporal.Now.instant().add({ seconds: -currentTime }),
+      end: Temporal.Now.instant().add({ seconds: 30 - currentTime }),
       duration: 30,
     },
   } satisfies ShowInfo;

--- a/playwright/ct-tests/useShowInfo/helpers.ts
+++ b/playwright/ct-tests/useShowInfo/helpers.ts
@@ -1,41 +1,41 @@
-import { addSeconds } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import type { ShowData } from '~/types/ShowData';
 
 export interface TestProps {
   offsetSec: number;
-  serverDateOverride?: Date;
+  serverDateOverride?: Temporal.Instant;
 }
 
 export function getMockData({
   offsetSec,
   serverDateOverride,
 }: TestProps): Pick<ShowData, 'slug' | 'serverDate' | 'sets'> {
-  const now = new Date();
+  const now = Temporal.Now.instant();
 
   return {
     slug: 'test',
-    serverDate: (serverDateOverride ?? now).toISOString(),
+    serverDate: (serverDateOverride ?? now).toString(),
     sets: [
       {
         id: 'cd062b08-596b-3dc7-8e7a-67f4395361a1',
         audioUrl: 'sample/energy-fix.mp3',
         artist: 'Artist 1',
-        start: addSeconds(now, 0 - offsetSec).toISOString(),
+        start: now.add({ seconds: 0 - offsetSec }).toString(),
         duration: 181.34,
       },
       {
         id: '87c6d911-b348-3aa2-a8ee-9d4ab9dbe3ca',
         audioUrl: 'sample/bust-this-bust-that.mp3',
         artist: 'Artist 2',
-        start: addSeconds(now, 250 - offsetSec).toISOString(),
+        start: now.add({ seconds: 250 - offsetSec }).toString(),
         duration: 268.64,
       },
       {
         id: '1f22deda-9263-3aef-b66a-aa58c48cd30e',
         audioUrl: 'sample/one-ride.mp3',
         artist: 'Artist 3',
-        start: addSeconds(now, 550 - offsetSec).toISOString(),
+        start: now.add({ seconds: 550 - offsetSec }).toString(),
         duration: 183.72,
       },
     ],

--- a/playwright/ct-tests/useShowInfo/useShowInfo.spec.tsx
+++ b/playwright/ct-tests/useShowInfo/useShowInfo.spec.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/experimental-ct-react';
-import { addSeconds, formatDistanceToNowStrict, subSeconds } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import { getMockData } from './helpers';
 import { ShowInfoTest } from './ShowInfoTest';
@@ -13,9 +13,15 @@ test('1 minute before the show', async ({ mount }) => {
   await expect(component).toContainText('Next set: Artist 2');
 });
 
-for (const offsetSec of [60, 120, 180]) {
-  const distance = formatDistanceToNowStrict(subSeconds(new Date(), offsetSec));
-  test(`${distance} into the show`, async ({ mount }) => {
+function pluralize(word: string, count: number): string {
+  return count === 1 ? word : `${word}s`;
+}
+
+for (const offsetMin of [1, 2, 3]) {
+  const offsetSec = offsetMin * 60;
+  test(`${offsetMin} ${pluralize('minute', offsetMin)} into the show`, async ({
+    mount,
+  }) => {
     const component = await mount(<ShowInfoTest offsetSec={offsetSec} />);
 
     await expect(component).toContainText('Status: PLAYING');
@@ -26,7 +32,7 @@ for (const offsetSec of [60, 120, 180]) {
 }
 
 test('4 minutes into the show', async ({ mount }) => {
-  const component = await mount(<ShowInfoTest offsetSec={240} />);
+  const component = await mount(<ShowInfoTest offsetSec={4 * 60} />);
 
   await expect(component).toContainText('Status: WAITING_UNTIL_START');
   await expect(component).toContainText('Seconds until set: 10');
@@ -34,9 +40,9 @@ test('4 minutes into the show', async ({ mount }) => {
   await expect(component).toContainText('Next set: Artist 3');
 });
 
-for (const offsetSec of [300, 360, 420, 480]) {
-  const distance = formatDistanceToNowStrict(subSeconds(new Date(), offsetSec));
-  test(`${distance} into the show`, async ({ mount }) => {
+for (const offsetMin of [5, 6, 7, 8]) {
+  const offsetSec = offsetMin * 60;
+  test(`${offsetMin} minutes into the show`, async ({ mount }) => {
     const component = await mount(<ShowInfoTest offsetSec={offsetSec} />);
 
     await expect(component).toContainText('Status: PLAYING');
@@ -47,7 +53,7 @@ for (const offsetSec of [300, 360, 420, 480]) {
 }
 
 test('9 minutes into the show', async ({ mount }) => {
-  const component = await mount(<ShowInfoTest offsetSec={540} />);
+  const component = await mount(<ShowInfoTest offsetSec={9 * 60} />);
 
   await expect(component).toContainText('Status: WAITING_UNTIL_START');
   await expect(component).toContainText('Seconds until set: 10');
@@ -55,9 +61,9 @@ test('9 minutes into the show', async ({ mount }) => {
   await expect(component).toContainText('Next set: None');
 });
 
-for (const offsetSec of [600, 660, 720]) {
-  const distance = formatDistanceToNowStrict(subSeconds(new Date(), offsetSec));
-  test(`${distance} into the show`, async ({ mount }) => {
+for (const offsetMin of [10, 11, 12]) {
+  const offsetSec = offsetMin * 60;
+  test(`${offsetMin} minutes into the show`, async ({ mount }) => {
     const component = await mount(<ShowInfoTest offsetSec={offsetSec} />);
 
     await expect(component).toContainText('Status: PLAYING');
@@ -68,7 +74,7 @@ for (const offsetSec of [600, 660, 720]) {
 }
 
 test('after the show', async ({ mount }) => {
-  const component = await mount(<ShowInfoTest offsetSec={780} />);
+  const component = await mount(<ShowInfoTest offsetSec={13 * 60} />);
 
   await expect(component).toContainText('Status: ENDED');
   await expect(component).toContainText('Current set: None');
@@ -79,7 +85,7 @@ test('adjusts start time based on server clock', async ({ mount }) => {
   const component = await mount(
     <ShowInfoTest
       offsetSec={0}
-      serverDateOverride={addSeconds(new Date(), 10)}
+      serverDateOverride={Temporal.Now.instant().add({ seconds: 10 })}
     />,
   );
 

--- a/playwright/helpers/show.ts
+++ b/playwright/helpers/show.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
-import { addSeconds } from 'date-fns';
 import { nanoid } from 'nanoid';
+import { Temporal } from 'temporal-polyfill';
 
 import { isDefined } from '~/utils/is-defined';
 
@@ -18,7 +18,7 @@ export async function deleteTestShows() {
   });
 }
 
-export async function seedShow(startDate: Date) {
+export async function seedShow(startDate: Temporal.Instant) {
   const [logoImageFile, backgroundImageFile] = await Promise.all([
     prisma.imageFile.create({
       data: {
@@ -40,7 +40,7 @@ export async function seedShow(startDate: Date) {
       name: 'Test Show',
       slug: randomShowSlug(),
       description: 'The best radio show on GitHub Actions!',
-      startDate,
+      startDate: startDate.toString(),
       timeZone: 'GMT',
       backgroundColor: '#000000',
       backgroundColorSecondary: '#000000',
@@ -101,6 +101,8 @@ export async function delayShow(slug: string) {
 
   await prisma.show.update({
     where: { id: show.id },
-    data: { startDate: addSeconds(new Date(), 10) },
+    data: {
+      startDate: Temporal.Now.instant().add({ seconds: 10 }).toString(),
+    },
   });
 }

--- a/playwright/tests/admin.spec.ts
+++ b/playwright/tests/admin.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { addMinutes } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import { deleteShow, randomShowSlug, seedShow } from '../helpers/show';
 
@@ -7,7 +7,7 @@ let adminShowId: string;
 let adminShowSlug: string;
 
 test.beforeAll(async () => {
-  const adminShow = await seedShow(addMinutes(new Date(), 5));
+  const adminShow = await seedShow(Temporal.Now.instant().add({ minutes: 5 }));
   adminShowId = adminShow.id;
   adminShowSlug = adminShow.slug;
 });

--- a/playwright/tests/global.setup.ts
+++ b/playwright/tests/global.setup.ts
@@ -1,5 +1,5 @@
 import { test as setup } from '@playwright/test';
-import { addMinutes } from 'date-fns';
+import { Temporal } from 'temporal-polyfill';
 
 import { deleteTestShows, seedShow } from '../helpers/show';
 import { authFile } from './shared-data';
@@ -15,15 +15,17 @@ import { authFile } from './shared-data';
 setup('seed show', async () => {
   await deleteTestShows();
 
-  const show = await seedShow(addMinutes(new Date(), 1));
+  const show = await seedShow(Temporal.Now.instant().add({ minutes: 1 }));
   process.env.SHOW_SLUG = show.slug;
   process.env.FIRST_ARTIST_NAME = show.sets[0]?.artist ?? '';
 
   // Add other shows to ensure that the root URL redirects to the earliest
   // upcoming show
-  const showLater = await seedShow(addMinutes(new Date(), 10));
+  const showLater = await seedShow(Temporal.Now.instant().add({ minutes: 10 }));
   process.env.SHOW_LATER_SLUG = showLater.slug;
-  const showEarlier = await seedShow(addMinutes(new Date(), -10));
+  const showEarlier = await seedShow(
+    Temporal.Now.instant().subtract({ minutes: 10 }),
+  );
   process.env.SHOW_EARLIER_SLUG = showEarlier.slug;
 });
 

--- a/prisma/migrations/20250210022530_test/migration.sql
+++ b/prisma/migrations/20250210022530_test/migration.sql
@@ -1,0 +1,6 @@
+DELETE FROM `Show`;
+
+-- AlterTable
+ALTER TABLE `Show` DROP COLUMN `createdAt`,
+    DROP COLUMN `updatedAt`,
+    MODIFY `startDate` VARCHAR(191) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,13 +8,11 @@ datasource db {
 }
 
 model Show {
-  id          String    @id @default(uuid())
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  id          String  @id @default(uuid())
   name        String
-  slug        String    @unique
+  slug        String  @unique
   description String?
-  startDate   DateTime? // UTC
+  startDate   String? // YYYY-MM-DDTHH:MM:SSZ
   timeZone    String
 
   backgroundColor          String?


### PR DESCRIPTION
- Fix bug where typing a startDate with 0 seconds would show "Invalid datetime"
- Fix bug where adding a show would cause a PrismaClientValidationError on the startDate field
- Remove date-fns
- Replace all date calculations with Temporal (via [temporal-polyfill](https://www.npmjs.com/package/temporal-polyfill))
